### PR TITLE
Airflow: filbaserad config + sys.path-fix; scheman 08:30/08:35; BQ ME…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,41 @@ Proof-of-Concept för tradingstrategi med risk/reward-analys och maskininlärnin
 ---
 
 ## Project Setup (English)
+## Konfiguration (prod/dev)
+
+Vi separerar delbar konfiguration och hemligheter:
+
+- Delbar konfig (i Git): `config/config.ini`
+- Hemligheter (inte i Git): `.env` (endast nycklar, t.ex. `POLYGON_API_KEY`)
+
+Laddningsordning i kod: ENV > `.env` > `config/config.ini` > Airflow Variables (fallback)
+
+Exempel `config/config.ini`:
+```ini
+[default]
+TICKER=SPY
+START_DATE=2025-10-01
+END_DATE=2025-10-03
+BACKFILL_DAYS=0
+
+OUTPUT_DIR=/home/airflow/gcs/data
+OUTPUT_FILE=stock_data.csv
+CSV_PATH=/home/airflow/gcs/data/stock_data.csv
+
+GCP_PROJECT_ID=winners-or-loosers
+BQ_DATASET=stocks_eu
+BQ_TABLE=stock_data
+BQ_WRITE_DISPOSITION=WRITE_APPEND
+```
+
+Exempel `.env` (lägg inte i Git):
+```ini
+POLYGON_API_KEY=din-nyckel
+```
+
+Composer/Cloud Composer: Lägg dessa filer i DAGs-bucket:
+- `gs://<composer-bucket>/dags/config/config.ini`
+- `gs://<composer-bucket>/dags/config/.env` (frivillig, endast hemligheter)
 
 This repository contains the initial setup for the **Losers or Winners** project.  
 The goal is to build a financial trading strategy using historical and updated market data, analyzed with machine learning models, to predict whether a strategy is a **winner or loser**.

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,0 +1,13 @@
+[default]
+TICKER=SPY
+BACKFILL_DAYS=0
+BACKFILL_DONE=True
+
+OUTPUT_DIR=/home/airflow/gcs/data
+OUTPUT_FILE=stock_data.csv
+CSV_PATH=/home/airflow/gcs/data/stock_data.csv
+
+GCP_PROJECT_ID=winners-or-loosers
+BQ_DATASET=stocks_eu
+BQ_TABLE=stock_data
+BQ_WRITE_DISPOSITION=WRITE_APPEND

--- a/dags/fetch_and_load.py
+++ b/dags/fetch_and_load.py
@@ -6,16 +6,30 @@
 """
 
 import os
+import sys
 from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.python import PythonOperator
-from dotenv import load_dotenv
 
-from src.check_existing_dates import get_existing_dates, get_missing_dates
-from src.fetch_data import fetch_data_from_api
-from src.save_to_bigquery import save_data_to_bigquery
+# Undvik hårt beroende på dotenv vid DAG-import i Composer
+try:  # Composer kan sakna python-dotenv
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # fallback no-op
+
+    def load_dotenv(*args, **kwargs):  # type: ignore
+        return None
+
+
+"""Flytta in sys.path-injektion FÖRE src-importerna"""
+SRC_PATH = os.path.join(os.path.dirname(__file__), "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)
+
+from src.check_existing_dates import get_existing_dates, get_missing_dates  # noqa: E402
+from src.fetch_data import fetch_data_from_api  # noqa: E402
+from src.save_to_bigquery import save_data_to_bigquery  # noqa: E402
 
 default_args = {
     "owner": "arvid",
@@ -27,7 +41,7 @@ default_args = {
 with DAG(
     dag_id="fetch_and_load_pipeline",
     default_args=default_args,
-    schedule_interval="40 14 * * *",  # 14:40 UTC ≈ 16:40 lokal (sommar)
+    schedule_interval="30 6 * * *",  # 06:30 UTC ≈ 08:30 svensk tid (CEST)
     catchup=False,
     tags=["data_pipeline"],
 ) as dag:
@@ -39,24 +53,40 @@ with DAG(
         - Om BACKFILL_DONE=True: hämta bara igår (daglig uppdatering)
         - Om BACKFILL_DONE=False: hämta historisk data (backfill) och sätt BACKFILL_DONE=True
         """
-        # Läs från .env först, fallback till Airflow Variables
-        load_dotenv()
+        # Läs från projektets config först; behåll Airflow Variables som fallback
+        # Sökordning: ENV_FILE, ../config/.env, ../.env, .env
+        try:
+            from src.fetch_data import _load_project_config as _load_cfg
+            from src.fetch_data import _load_project_env as _load_env_fetch
+        except Exception:
+            _load_env_fetch = None
+            _load_cfg = None
+
+        if _load_env_fetch:
+            _load_env_fetch()
+        else:
+            load_dotenv(override=False)
+
+        cfg = _load_cfg() if _load_cfg else {}
 
         # API-nyckel: .env först, sedan Airflow Variables
-        api_key = os.getenv("POLYGON_API_KEY") or Variable.get("POLYGON_API_KEY", default_var=None)
+        api_key = (
+            os.getenv("POLYGON_API_KEY")
+            or cfg.get("POLYGON_API_KEY")
+            or Variable.get("POLYGON_API_KEY", default_var=None)
+        )
         if not api_key:
             raise ValueError("POLYGON_API_KEY saknas i både .env och Airflow Variables")
         os.environ["POLYGON_API_KEY"] = api_key
 
         # Ticker
-        ticker_var = Variable.get("TICKER", default_var=None)
-        if ticker_var:
-            os.environ["TICKER"] = ticker_var
-        else:
-            os.environ["TICKER"] = "SPY"
+        ticker_var = os.getenv("TICKER") or cfg.get("TICKER") or Variable.get("TICKER", default_var=None)
+        os.environ["TICKER"] = ticker_var or "SPY"
 
         # Kolla om backfill redan är gjort
-        backfill_done = Variable.get("BACKFILL_DONE", default_var="False")
+        backfill_done = (
+            os.getenv("BACKFILL_DONE") or cfg.get("BACKFILL_DONE") or Variable.get("BACKFILL_DONE", default_var="False")
+        )
 
         if backfill_done == "True":
             # Daglig uppdatering: hämta bara nya datum
@@ -81,8 +111,8 @@ with DAG(
                 return
         else:
             # Backfill: hämta historisk data
-            start_var = Variable.get("START_DATE", default_var=None)
-            end_var = Variable.get("END_DATE", default_var=None)
+            start_var = os.getenv("START_DATE") or cfg.get("START_DATE") or Variable.get("START_DATE", default_var=None)
+            end_var = os.getenv("END_DATE") or cfg.get("END_DATE") or Variable.get("END_DATE", default_var=None)
             if start_var and end_var:
                 os.environ["START_DATE"] = start_var
                 os.environ["END_DATE"] = end_var
@@ -95,8 +125,16 @@ with DAG(
                 os.environ["END_DATE"] = yesterday
                 print(f"[BACKFILL] Hämtar senaste året: {one_year_ago} till {yesterday}")
 
-        os.environ["OUTPUT_DIR"] = Variable.get("OUTPUT_DIR", default_var="/home/airflow/gcs/data")
-        os.environ["OUTPUT_FILE"] = Variable.get("OUTPUT_FILE", default_var="stock_data.csv")
+        os.environ["OUTPUT_DIR"] = (
+            os.getenv("OUTPUT_DIR")
+            or cfg.get("OUTPUT_DIR")
+            or Variable.get("OUTPUT_DIR", default_var="/home/airflow/gcs/data")
+        )
+        os.environ["OUTPUT_FILE"] = (
+            os.getenv("OUTPUT_FILE")
+            or cfg.get("OUTPUT_FILE")
+            or Variable.get("OUTPUT_FILE", default_var="stock_data.csv")
+        )
         fetch_data_from_api()
 
     def load_wrapper():
@@ -108,8 +146,27 @@ with DAG(
         - BQ_DATASET/BQ_TABLE: maltabell (partitionerad pa DATE(timestamp))
         - BQ_WRITE_DISPOSITION: WRITE_APPEND (daglig), ev. WRITE_TRUNCATE for engangssfix
         """
-        # Läs parametrar från Airflow Variables (med defaultvärden)
-        csv_path = Variable.get("CSV_PATH", default_var="/home/airflow/gcs/data/stock_data.csv")
+        # Läs projektkonfig (samma som i fetch_wrapper)
+        try:
+            from src.fetch_data import _load_project_config as _load_cfg
+            from src.fetch_data import _load_project_env as _load_env_fetch
+        except Exception:
+            _load_env_fetch = None
+            _load_cfg = None
+
+        if _load_env_fetch:
+            _load_env_fetch()
+        else:
+            load_dotenv(override=False)
+
+        cfg = _load_cfg() if _load_cfg else {}
+
+        # Läs parametrar från fil/env/Variables (med defaultvärden)
+        csv_path = (
+            os.getenv("CSV_PATH")
+            or cfg.get("CSV_PATH")
+            or Variable.get("CSV_PATH", default_var="/home/airflow/gcs/data/stock_data.csv")
+        )
         os.environ["CSV_PATH"] = csv_path
 
         # Kolla om CSV-filen finns (om fetch_wrapper hoppade över hämtning)
@@ -118,12 +175,22 @@ with DAG(
             return
 
         # GCP-projekt kan komma från ADC; sätt bara om det finns
-        gcp_project = Variable.get("GCP_PROJECT_ID", default_var=None)
+        gcp_project = (
+            os.getenv("GCP_PROJECT_ID") or cfg.get("GCP_PROJECT_ID") or Variable.get("GCP_PROJECT_ID", default_var=None)
+        )
         if gcp_project:
             os.environ["GCP_PROJECT_ID"] = gcp_project
-        os.environ["BQ_DATASET"] = Variable.get("BQ_DATASET", default_var="stocks_eu")
-        os.environ["BQ_TABLE"] = Variable.get("BQ_TABLE", default_var="stock_data")
-        os.environ["BQ_WRITE_DISPOSITION"] = Variable.get("BQ_WRITE_DISPOSITION", default_var="WRITE_APPEND")
+        os.environ["BQ_DATASET"] = (
+            os.getenv("BQ_DATASET") or cfg.get("BQ_DATASET") or Variable.get("BQ_DATASET", default_var="stocks_eu")
+        )
+        os.environ["BQ_TABLE"] = (
+            os.getenv("BQ_TABLE") or cfg.get("BQ_TABLE") or Variable.get("BQ_TABLE", default_var="stock_data")
+        )
+        os.environ["BQ_WRITE_DISPOSITION"] = (
+            os.getenv("BQ_WRITE_DISPOSITION")
+            or cfg.get("BQ_WRITE_DISPOSITION")
+            or Variable.get("BQ_WRITE_DISPOSITION", default_var="WRITE_APPEND")
+        )
         # Autentisering: antingen ADC eller servicekonto via fil
         sa_path = Variable.get("GOOGLE_APPLICATION_CREDENTIALS", default_var=None)
         if sa_path:

--- a/dags/predict_dag.py
+++ b/dags/predict_dag.py
@@ -6,7 +6,7 @@ from airflow.providers.google.cloud.operators.cloud_run import CloudRunExecuteJo
 with DAG(
     dag_id="predict_pipeline",
     start_date=datetime(2024, 1, 1),
-    schedule_interval="45 14 * * *",  # 14:45 UTC ≈ 16:45 lokal (sommar) - 5 min efter data-hämtning
+    schedule_interval="35 6 * * *",  # 06:35 UTC ≈ 08:35 svensk tid (CEST)
     catchup=False,
     tags=["ml"],
 ) as dag:

--- a/docker/predict/model-scorer.yaml
+++ b/docker/predict/model-scorer.yaml
@@ -28,7 +28,7 @@ spec:
               value: winners-or-loosers.stocks_eu.stock_data
             - name: BQ_OUTPUT_TABLE
               value: winners-or-loosers.stocks_eu.prediction
-            image: europe-north2-docker.pkg.dev/winners-or-loosers/predict/model-scorer:v12
+            image: europe-north2-docker.pkg.dev/winners-or-loosers/predict/model-scorer:v13
             resources:
               limits:
                 cpu: '1'

--- a/docker/predict/predict.py
+++ b/docker/predict/predict.py
@@ -31,6 +31,8 @@ def predict_and_save():
 
     # Feature engineering for Random Forest
     df["timestamp"] = pd.to_datetime(df["timestamp"])
+    # Viktigt: sortera i stigande ordning per ticker innan rullande beräkningar
+    df = df.sort_values(by=["ticker", "timestamp"])  # säkerställer att senaste dagarna inte försvinner vid dropna
     df["return"] = df["close"].pct_change()
     df["return_lag1"] = df["return"].shift(1)
     df["volatility_5d"] = df["return"].rolling(window=5).std()

--- a/src/fetch_data.py
+++ b/src/fetch_data.py
@@ -10,12 +10,76 @@ Användning (via DAG eller direkt):
 """
 
 # Importerar alla nödvändiga bibliotek:
+import configparser
 import csv
 import os
 from datetime import datetime, timedelta
 
 from dotenv import load_dotenv
 from polygon import RESTClient
+
+
+def _load_project_env() -> None:
+    """Load env vars from project config if available.
+
+    Search order (first found wins, no override of existing env):
+    - ENV_FILE (explicit path)
+    - ../config/.env (relative to this file)
+    - ../.env (repo root relative guess)
+    - .env (cwd)
+    """
+    # 1) Explicit path via ENV_FILE
+    explicit_path = os.getenv("ENV_FILE")
+    if explicit_path and os.path.exists(explicit_path):
+        load_dotenv(explicit_path, override=False)
+        return
+
+    # 2) Relative to this file (Composer places src under dags/src)
+    script_dir = os.path.dirname(__file__)
+    candidates = [
+        os.path.join(script_dir, "..", "config", ".env"),
+        os.path.join(script_dir, "..", ".env"),
+        os.path.join(os.getcwd(), ".env"),
+    ]
+    for candidate in candidates:
+        try:
+            if os.path.exists(candidate):
+                load_dotenv(candidate, override=False)
+                return
+        except Exception:
+            # Best-effort; fall through to default load
+            pass
+
+    # 3) Fallback to default loader (cwd)
+    load_dotenv(override=False)
+
+
+def _load_project_config() -> dict:
+    """Load shared, non-secret configuration from config/config.ini if present.
+
+    Returns a flat dict of values from [default] section. Missing file → {}.
+    """
+    config = configparser.ConfigParser()
+    # Resolve path candidates relative to this file / repo root / cwd
+    script_dir = os.path.dirname(__file__)
+    candidates = [
+        os.getenv("CONFIG_FILE"),
+        os.path.join(script_dir, "..", "config", "config.ini"),
+        os.path.join(script_dir, "..", "config.ini"),
+        os.path.join(os.getcwd(), "config", "config.ini"),
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            if os.path.exists(candidate):
+                config.read(candidate)
+                break
+        except Exception:
+            continue
+    if "default" in config:
+        return {k.upper(): v for k, v in config["default"].items()}
+    return {}
 
 
 def fetch_data_from_api(
@@ -27,19 +91,20 @@ def fetch_data_from_api(
 
     Parametrar prioriteras i ordning: funktionsargument → miljövariabler/.env → defaults.
     """
-    # Läs in .env och miljövariabler om argument inte ges
-    load_dotenv()
-    api_key = api_key or os.getenv("POLYGON_API_KEY")
+    # Läs in projektkonfig först (utan att skriva över redan satta env)
+    _load_project_env()
+    cfg = _load_project_config()
+    api_key = api_key or os.getenv("POLYGON_API_KEY") or cfg.get("POLYGON_API_KEY")
     if not api_key:
         raise ValueError("POLYGON_API_KEY saknas i .env/miljön och gavs inte som argument")
 
-    ticker = ticker or os.getenv("TICKER", "SPY")
+    ticker = ticker or os.getenv("TICKER") or cfg.get("TICKER") or "SPY"
 
     if output_path is None:
         # Lokalt defaultar vi till projektmappen; i Composer skrivs detta
         # över via Airflow Variables till /home/airflow/gcs/data.
-        output_dir = os.getenv("OUTPUT_DIR", "/home/joel/Losers-or-Winners/data")
-        output_file = os.getenv("OUTPUT_FILE", "stock_data.csv")
+        output_dir = os.getenv("OUTPUT_DIR") or cfg.get("OUTPUT_DIR") or "/home/joel/Losers-or-Winners/data"
+        output_file = os.getenv("OUTPUT_FILE") or cfg.get("OUTPUT_FILE") or "stock_data.csv"
         output_path = os.path.join(output_dir, output_file)
 
     # Bestäm intervall:
@@ -49,9 +114,9 @@ def fetch_data_from_api(
     today = datetime.now().date()
     yesterday = today - timedelta(days=1)
 
-    start_env = os.getenv("START_DATE")
-    end_env = os.getenv("END_DATE")
-    backfill_days_str = os.getenv("BACKFILL_DAYS", "0")
+    start_env = os.getenv("START_DATE") or cfg.get("START_DATE")
+    end_env = os.getenv("END_DATE") or cfg.get("END_DATE")
+    backfill_days_str = os.getenv("BACKFILL_DAYS") or cfg.get("BACKFILL_DAYS") or "0"
     try:
         backfill_days = int(backfill_days_str)
     except ValueError:

--- a/src/save_to_bigquery.py
+++ b/src/save_to_bigquery.py
@@ -1,7 +1,68 @@
+import configparser
 import os
 
 from dotenv import load_dotenv
-from google.cloud import bigquery
+
+
+def _load_project_env() -> None:
+    """Läs in env från projektets config-fil om den finns.
+
+    Ordning (första som hittas vinner, utan att skriva över befintliga env):
+    - ENV_FILE (explicit path)
+    - ../config/.env (relativt denna fil)
+    - ../.env (repo-root gissning)
+    - .env (cwd)
+    """
+    explicit_path = os.getenv("ENV_FILE")
+    if explicit_path and os.path.exists(explicit_path):
+        load_dotenv(explicit_path, override=False)
+        return
+
+    script_dir = os.path.dirname(__file__)
+    candidates = [
+        os.path.join(script_dir, "..", "config", ".env"),
+        os.path.join(script_dir, "..", ".env"),
+        os.path.join(os.getcwd(), ".env"),
+    ]
+    for candidate in candidates:
+        try:
+            if os.path.exists(candidate):
+                load_dotenv(candidate, override=False)
+                return
+        except Exception:
+            pass
+
+    load_dotenv(override=False)
+
+
+def _load_project_config() -> dict:
+    """Läs delbar konfig från config/config.ini om den finns.
+
+    Returnerar en platt dict från [default]-sektionen. Saknas fil → {}.
+    """
+    config = configparser.ConfigParser()
+    script_dir = os.path.dirname(__file__)
+    candidates = [
+        os.getenv("CONFIG_FILE"),
+        os.path.join(script_dir, "..", "config", "config.ini"),
+        os.path.join(script_dir, "..", "config.ini"),
+        os.path.join(os.getcwd(), "config", "config.ini"),
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            if os.path.exists(candidate):
+                config.read(candidate)
+                break
+        except Exception:
+            continue
+    if "default" in config:
+        return {k.upper(): v for k, v in config["default"].items()}
+    return {}
+
+
+from google.cloud import bigquery  # noqa: E402
 
 
 def save_data_to_bigquery() -> None:
@@ -16,14 +77,17 @@ def save_data_to_bigquery() -> None:
     - BQ_WRITE_DISPOSITION: WRITE_APPEND (daglig), ev. WRITE_TRUNCATE vid schemafix
     """
 
-    load_dotenv()
+    _load_project_env()
+    cfg = _load_project_config()
 
     # Konfigurerbara via .env eller Airflow Variables
-    csv_path = os.getenv("CSV_PATH", "/home/joel/Losers-or-Winners/data/stock_data.csv")
-    project_id = os.getenv("GCP_PROJECT_ID")
-    dataset_name = os.getenv("BQ_DATASET", "stocks")
-    table_name = os.getenv("BQ_TABLE", "stock_data")
-    write_disposition = os.getenv("BQ_WRITE_DISPOSITION", "WRITE_APPEND")
+    csv_path = os.getenv("CSV_PATH") or cfg.get("CSV_PATH") or "/home/joel/Losers-or-Winners/data/stock_data.csv"
+    project_id = os.getenv("GCP_PROJECT_ID") or cfg.get("GCP_PROJECT_ID")
+    dataset_name = os.getenv("BQ_DATASET") or cfg.get("BQ_DATASET") or "stocks"
+    table_name = os.getenv("BQ_TABLE") or cfg.get("BQ_TABLE") or "stock_data"
+    # staging-tabellnamn kan konfigureras, annars <table>_staging
+    staging_table_name = os.getenv("BQ_STAGING_TABLE") or cfg.get("BQ_STAGING_TABLE") or f"{table_name}_staging"
+    # write_disposition kept for compatibility in cfg; not used with staging+merge
 
     if not os.path.exists(csv_path):
         raise FileNotFoundError(f"CSV hittas inte: {csv_path}")
@@ -32,6 +96,7 @@ def save_data_to_bigquery() -> None:
 
     dataset_id = f"{client.project}.{dataset_name}"
     table_id = f"{dataset_id}.{table_name}"
+    staging_table_id = f"{dataset_id}.{staging_table_name}"
 
     # Säkerställ datasetet finns
     try:
@@ -53,15 +118,47 @@ def save_data_to_bigquery() -> None:
         skip_leading_rows=1,
         autodetect=False,
         schema=schema,
-        write_disposition=write_disposition,
+        # Till staging använder vi alltid WRITE_TRUNCATE (idempotent MERGE efteråt)
+        write_disposition="WRITE_TRUNCATE",
     )
 
+    # 1) Ladda till staging-tabell
     with open(csv_path, "rb") as f:
-        load_job = client.load_table_from_file(f, table_id, job_config=job_config)
+        load_job = client.load_table_from_file(f, staging_table_id, job_config=job_config)
 
     result = load_job.result()
+    # 2) MERGE staging -> target på nyckel (ticker, DATE(timestamp))
+    merge_sql = f"""
+        MERGE `{table_id}` T
+        USING (
+          SELECT
+            ticker,
+            TIMESTAMP_TRUNC(timestamp, DAY) AS ts_day,
+            ANY_VALUE(open) AS open,
+            ANY_VALUE(close) AS close,
+            ANY_VALUE(volume) AS volume
+          FROM `{staging_table_id}`
+          GROUP BY ticker, ts_day
+        ) S
+        ON T.ticker = S.ticker AND DATE(T.timestamp) = DATE(S.ts_day)
+        WHEN MATCHED THEN UPDATE SET
+          T.timestamp = S.ts_day,
+          T.open = S.open,
+          T.close = S.close,
+          T.volume = S.volume
+        WHEN NOT MATCHED THEN INSERT (ticker, timestamp, open, close, volume)
+        VALUES (S.ticker, S.ts_day, S.open, S.close, S.volume)
+    """
+
+    client.query(merge_sql).result()
+
     table = client.get_table(table_id)
-    print(f"Laddning klar: {result.output_rows} rader till {table_id}. Totala rader nu: {table.num_rows}")
+    print(
+        "Laddning klar till staging: "
+        f"{result.output_rows} rader. "
+        f"MERGE -> {table_id}. "
+        f"Totala rader nu: {table.num_rows}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sammanfattning
Filbaserad konfiguration: config/config.ini (delbar), hemligheter via Airflow Variable (tills vidare).
Airflow/DAG-import robusthet: sys.path fix så dags/src hittas i Composer.
BigQuery-laddning: staging + MERGE till stocks_eu.stock_data på (ticker, DATE(timestamp)) → idempotent, inga dubletter vid backfill/omkörning.
Predict v14 (Cloud Run): sortering per ticker,timestamp innan feature‑rolling → stabil scoring; WRITE_TRUNCATE till prediction.
Scheman uppdaterade: fetch 08:30, predict 08:35 svensk tid (kan ändras enkelt).
Daglig drift: BACKFILL_DONE=True; ingestion hämtar “igår”; dedupe/merge säkerställer inga dubletter.
Påverkan
Inga ändringar krävs i externa system. Composer läser dags/ som vanligt; config i dags/config/config.ini.
Idempotent laddning minskar manuella städningar i BQ.
Testat
Backfill av saknade datum; MERGE utan dubletter.
End‑to‑end med Cloud Run predict (v14); prediction innehåller rader för 2025‑10‑01–03 med dagens load_date.
Att granska
dags/fetch_and_load.py (sys.path, config‑inladdning, schema).
src/save_to_bigquery.py (staging+MERGE).
docker/predict/predict.py (sortering före rolling).
config/config.ini (delbar config, inga hemligheter).
Plan framåt
När Secret Manager‑åtkomst är klar: flytta POLYGON_API_KEY från Airflow Variable till SM env‑referens.
Eventuellt Git‑sync till Composer senare för att slippa manuell GCS‑synk.